### PR TITLE
Remove escape handling from quote validation

### DIFF
--- a/src/parser/parser_main_run.c
+++ b/src/parser/parser_main_run.c
@@ -12,51 +12,87 @@
 
 #include "parser.h"
 
-int	pm_prepare(t_mshell *mshell, const char *cmd, char **out_exp)
+static int      pm_has_unclosed_quotes(const char *cmd)
 {
-	char	*exp;
+        size_t  i;
+        int             in_squote;
+        int             in_dquote;
 
-	if (!pm_store_raw_command(mshell, cmd))
-		return (-1);
-	exp = pm_expand_cmd(cmd, mshell);
-	if (!exp)
-		return (-1);
-	if (pm_is_empty_or_whitespace(exp))
-	{
-		ft_free((void **)&exp);
-		mshell->tree = NULL;
-		return (0);
-	}
-	if (!pm_store_expanded(mshell, exp))
-		return (ft_free((void **)&exp), -1);
-	*out_exp = exp;
-	return (1);
+        i = 0;
+        in_squote = 0;
+        in_dquote = 0;
+        while (cmd[i])
+        {
+                if (!in_dquote && cmd[i] == '\'')
+                        in_squote = !in_squote;
+                else if (!in_squote && cmd[i] == '"')
+                        in_dquote = !in_dquote;
+                i++;
+        }
+        return (in_squote || in_dquote);
 }
 
-int	pm_parse_store(t_mshell *mshell, char *exp)
+static int      pm_validate_quotes(const char *cmd, t_mshell *mshell)
 {
-	t_ent	*root;
-
-	root = pm_parse_tree_or_error(exp, mshell);
-	if (!root)
-	{
-		ft_free((void **)&exp);
-		mshell->tree = NULL;
-		return (0);
-	}
-	mshell->tree = root;
-	ft_free((void **)&exp);
-	return (1);
+        if (!cmd)
+                return (1);
+        if (!pm_has_unclosed_quotes(cmd))
+                return (1);
+        print_err2("minishell: syntax error near unexpected token `newline'\n",
+                NULL, NULL);
+        if (mshell->exit_code == 0)
+                mshell->exit_code = 2;
+        mshell->tree = NULL;
+        return (0);
 }
 
-int	pm_run(t_mshell *mshell, const char *cmd)
+int     pm_prepare(t_mshell *mshell, const char *cmd, char **out_exp)
 {
-	char	*exp;
-	int		st;
+        char    *exp;
 
-	st = pm_prepare(mshell, cmd, &exp);
-	if (st <= 0)
-		return (0);
-	pm_parse_store(mshell, exp);
-	return (0);
+        if (!pm_store_raw_command(mshell, cmd))
+                return (-1);
+        if (!pm_validate_quotes(cmd, mshell))
+                return (0);
+        exp = pm_expand_cmd(cmd, mshell);
+        if (!exp)
+                return (-1);
+        if (pm_is_empty_or_whitespace(exp))
+        {
+                ft_free((void **)&exp);
+                mshell->tree = NULL;
+                return (0);
+        }
+        if (!pm_store_expanded(mshell, exp))
+                return (ft_free((void **)&exp), -1);
+        *out_exp = exp;
+        return (1);
+}
+
+int     pm_parse_store(t_mshell *mshell, char *exp)
+{
+        t_ent   *root;
+
+        root = pm_parse_tree_or_error(exp, mshell);
+        if (!root)
+        {
+                ft_free((void **)&exp);
+                mshell->tree = NULL;
+                return (0);
+        }
+        mshell->tree = root;
+        ft_free((void **)&exp);
+        return (1);
+}
+
+int     pm_run(t_mshell *mshell, const char *cmd)
+{
+        char    *exp;
+        int             st;
+
+        st = pm_prepare(mshell, cmd, &exp);
+        if (st <= 0)
+                return (0);
+        pm_parse_store(mshell, exp);
+        return (0);
 }


### PR DESCRIPTION
## Summary
- drop the backslash escape helper and stop skipping characters when scanning for unmatched quotes
- keep the unmatched-quote validation so commands with unclosed quotes still raise the syntax error

## Testing
- make *(fails: dependency repository cannot be cloned because outbound network access is blocked in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d447a7f834832f9d0a987aeda55561